### PR TITLE
Adding amazon.co.jp to manifest file

### DIFF
--- a/Amazon Sort Number of Reviews/manifest.json
+++ b/Amazon Sort Number of Reviews/manifest.json
@@ -10,6 +10,7 @@
 		"matches": ["*://www.amazon.com/*",
 			"*://smile.amazon.com/*",
 			"*://www.amazon.co.uk/*",
+			"*://www.amazon.co.jp/*",
 			"*://www.amazon.ca/*",
 			"*://www.amazon.de/*",
 			"*://www.amazon.it/*",


### PR DESCRIPTION
This extension also works with amazon.co.jp, so I added it to the manifest file.
I'm using it locally, but it would be great if you could add it to the official version.